### PR TITLE
change the current buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,7 +11,7 @@
     "heroku-postgresql"
   ],
   "env": {
-  	"BUILDPACK_URL": "https://github.com/kr/heroku-buildpack-go"
+  	"BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-go"
   },
   "repository": "https://github.com/9uuso/vertigo"
 }


### PR DESCRIPTION
this buildpack is an official fork by heroku of the "kr/heroku-buildpack-go" repo which is no longer developed upon