### PR TITLE
fix git clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note: To deploy to Heroku you need to have a credit card linked to them. If you 
 
 1. Install Go (I recommend using [gvm](https://github.com/moovweb/gvm))
 2. `go get github.com/tools/godep`
-3. `git clone github.com/9uuso/vertigo`
+3. `git clone https://github.com/9uuso/vertigo`
 4. `cd vertigo && godep get ./ && godep go build`
 5. `PORT="80" MARTINI_ENV="production" ./vertigo`
 


### PR DESCRIPTION
prevents "fatal: repository 'github.com/9uuso/vertigo' does not exist"