### PR TITLE
remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,8 +9,5 @@
   "addons": [
     "heroku-postgresql"
   ],
-  "env": {
-  	"BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-go"
-  },
   "repository": "https://github.com/9uuso/vertigo"
 }


### PR DESCRIPTION
This is no longer required as we officially support Go: https://blog.heroku.com/archives/2015/7/7/go_support_now_official_on_heroku